### PR TITLE
Handle new users who don't have RecentPairUps

### DIFF
--- a/Source/v3Net/MeetupBot/Helpers/MeetupBotDataProvider.cs
+++ b/Source/v3Net/MeetupBot/Helpers/MeetupBotDataProvider.cs
@@ -130,7 +130,8 @@
             {
                 TenantId = tenantId,
                 UserId = userId,
-                OptedIn = optedIn
+                OptedIn = optedIn,
+                RecentPairUps = new List<string>()
             };
 
             obj = await StoreUserOptInStatus(obj);
@@ -152,7 +153,7 @@
             };
             if (userOptInInfo.TryGetValue(userId1, out UserOptInInfo initialUser1Info))
             {
-                user1Info.RecentPairUps = initialUser1Info.RecentPairUps;
+                user1Info.RecentPairUps = initialUser1Info.RecentPairUps ?? new List<string>();
                 user1Info.Id = initialUser1Info.Id;
             }
             else
@@ -168,7 +169,7 @@
             };
             if (userOptInInfo.TryGetValue(userId2, out UserOptInInfo initialUser2Info))
             {
-                user2Info.RecentPairUps = initialUser2Info.RecentPairUps;
+                user2Info.RecentPairUps = initialUser2Info.RecentPairUps ?? new List<string>();
                 user2Info.Id = initialUser2Info.Id;
             }
             else

--- a/Source/v3Net/MeetupBot/MeetupBot.cs
+++ b/Source/v3Net/MeetupBot/MeetupBot.cs
@@ -241,7 +241,7 @@
                 // Find the first person they haven't been paired with recently.
                 while (user2 == null && pointer < users.Count)
                 {
-                    if (user1OptIn == null || user1OptIn.RecentPairUps?.Contains(users[pointer].ObjectId) == false)
+                    if (user1OptIn?.RecentPairUps == null || !user1OptIn.RecentPairUps.Contains(users[pointer].ObjectId))
                     {
                         user2 = users[pointer];
                     }

--- a/Source/v3Net/MeetupBot/MeetupBot.cs
+++ b/Source/v3Net/MeetupBot/MeetupBot.cs
@@ -241,7 +241,7 @@
                 // Find the first person they haven't been paired with recently.
                 while (user2 == null && pointer < users.Count)
                 {
-                    if (user1OptIn == null || !user1OptIn.RecentPairUps.Contains(users[pointer].ObjectId))
+                    if (user1OptIn == null || user1OptIn.RecentPairUps?.Contains(users[pointer].ObjectId) == false)
                     {
                         user2 = users[pointer];
                     }


### PR DESCRIPTION
Found a bug in my recent change to store history; pushing a fix here! Folks who had just recently joined had null RecentPairUps, so we would throw if they ended up as "user1" in the pairing process.