### PR TITLE
added try catch because if user has set Block conversations with bots - Pairups not happening

### DIFF
--- a/Source/v3Net/MeetupBot/MeetupBot.cs
+++ b/Source/v3Net/MeetupBot/MeetupBot.cs
@@ -148,7 +148,15 @@
                 if (! isTesting)
                 {
                     // shoot the activity over
-                    await connectorClient.Conversations.SendToConversationAsync(activity, response.Id);
+                    // added try catch because if user has set "Block conversations with bots"
+                    try
+                    {
+                        await connectorClient.Conversations.SendToConversationAsync(activity, response.Id);
+                    }
+                    catch (UnauthorizedAccessException uae)
+                    {
+                        System.Diagnostics.Trace.TraceError($"Failed to notify user due to error {uae.ToString()}");
+                    }
                 }
                 
             }


### PR DESCRIPTION
Issue:  If user has set Block conversations with bots -throwing exception and rest of the pairup notifications are not being sent and pairups are not saving into DB

Fix: Added Try Catch block